### PR TITLE
Fix crasher with xmpp4r.

### DIFF
--- a/lib/lita/adapters/hipchat.rb
+++ b/lib/lita/adapters/hipchat.rb
@@ -59,7 +59,7 @@ module Lita
       end
 
       def muc_domain
-        config.muc_domain || "conf.hipchat.com"
+        config.muc_domain.nil? ? "conf.hipchat.com" : config.muc_domain.dup
       end
 
       def rooms


### PR DESCRIPTION
Under Lita 3.0.1, lita-hipchat crashes on launch because of the new frozen config inside of xmpp4r.

```
xmpp4r-0.5.6/lib/xmpp4r/jid.rb:40:in `downcase!': can't modify frozen String (RuntimeError)
```

This dupes the string from the config on connect to prevent the crashing inside of xmpp4r.  All specs passed and now my bot connects again.  I figured instead of complaining I should just send a fix.
