### PR TITLE
Parted / Joined robot triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ test/tmp
 test/version_tmp
 tmp
 lita_config.rb
-bin/*

--- a/lib/lita/adapters/hipchat.rb
+++ b/lib/lita/adapters/hipchat.rb
@@ -15,7 +15,7 @@ module Lita
 
       def join(room_id)
         connector.join(muc_domain, room_id)
-        robot.trigger(:joined, :room => room_id)
+        robot.trigger(:joined, room: room_id)
       end
 
       def mention_format(name)
@@ -23,7 +23,7 @@ module Lita
       end
 
       def part(room_id)
-        robot.trigger(:parted, :room => room_id)
+        robot.trigger(:parted, room: room_id)
         connector.part(muc_domain, room_id)
       end
 
@@ -54,6 +54,8 @@ module Lita
         robot.trigger(:disconnected)
       end
 
+      private
+
       def rooms
         if config.rooms == :all
           connector.list_rooms(muc_domain)
@@ -61,8 +63,6 @@ module Lita
           Array(config.rooms)
         end
       end
-
-      private
 
       def config
         Lita.config.adapter

--- a/spec/lita/adapters/hipchat_spec.rb
+++ b/spec/lita/adapters/hipchat_spec.rb
@@ -31,7 +31,7 @@ describe Lita::Adapters::HipChat do
   describe "#join" do
     let(:room) { "#foo" }
     before do
-      allow(robot).to receive(:trigger).with(:joined, :room => room)
+      allow(robot).to receive(:trigger).with(:joined, room: room)
     end
     it "joins a room" do
       expect(subject.connector).to receive(:join).with(domain, room)
@@ -46,9 +46,9 @@ describe Lita::Adapters::HipChat do
   end
 
   describe "#part" do
-    let(:room) { "#foo"}
+    let(:room) { "#foo" }
     before do
-      allow(robot).to receive(:trigger).with(:parted, :room => room)
+      allow(robot).to receive(:trigger).with(:parted, room: room)
     end
     it "parts from a room" do
       expect(subject.connector).to receive(:part).with(domain, room)


### PR DESCRIPTION
I wanted my bots to be able to do stuff when they join / leave rooms, my idea is to provide simple events for handlers to listen to. What do you think?

Changes:
- Added adapter triggering robot events for joining and parting rooms
- Changed #run to use the adapter #join instead of connector join_rooms directly (so events get triggered)
- Changed #shutdown to call #part on each room before shutting down
- Changed #rooms visibility to public (may be unnecessary but i wanted to be able to access rooms from events in handlers)
- Specs refactors / fixes

Regards,
Darkside.
