### PR TITLE
Force UTF-8 encoding and character replacement

### DIFF
--- a/lib/lita/adapters/hipchat/connector.rb
+++ b/lib/lita/adapters/hipchat/connector.rb
@@ -63,10 +63,7 @@ module Lita
         def message_jid(user_jid, strings)
           strings.each do |s|
             Lita.logger.debug("Sending message to JID #{user_jid}: #{s}")
-            message = Jabber::Message.new(user_jid,
-                                          s.encode('UTF-8',
-                                                   :invalid => :replace,
-                                                   :undef => :replace))
+            message = Jabber::Message.new(user_jid, encode_string(s))
             message.type = :chat
             client.send(message)
           end
@@ -76,7 +73,7 @@ module Lita
           muc = mucs[room_jid]
           strings.each do |s|
             Lita.logger.debug("Sending message to MUC #{room_jid}: #{s}")
-            muc.say(s.encode('UTF-8', :invalid => :replace, :undef => :replace))
+            muc.say(encode_string(s))
           end if muc
         end
 
@@ -142,6 +139,10 @@ module Lita
             jid.domain = domain
           end
           jid
+        end
+
+        def encode_string(s)
+          s.encode('UTF-8', :invalid => :replace, :undef => :replace)
         end
       end
     end


### PR DESCRIPTION
I admit this is a hacky fix, and I'm open to suggestions on how to do this better.

Problem description:

When sending certain characters, Hipchat resets the connection.  This is a Bad Thing(tm) - Lita does not reconnect, nor does it exit.

Repro steps:

With the lita-whois handler and lita-hipchat adapter installed, do:

```
!whois 194.132.177.163
```

and the adapter will disconnect, and show the following in debug mode:

```
W, [2014-07-18T11:41:45.351138 #58034]  WARN -- : EXCEPTION:
    Errno::ECONNRESET
    Connection reset by peer
    /Users/esigler/.rvm/gems/ruby-2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/connection.rb:45:in `sysread'
    /Users/esigler/.rvm/gems/ruby-2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/connection.rb:45:in `sysread'
    /Users/esigler/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/openssl/buffering.rb:61:in `fill_rbuff'
    /Users/esigler/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/openssl/buffering.rb:301:in `eof?'
    /Users/esigler/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/rexml/source.rb:235:in `empty?'
    /Users/esigler/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/rexml/parsers/baseparser.rb:148:in `empty?'
    /Users/esigler/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/rexml/parsers/baseparser.rb:196:in `pull_event'
    /Users/esigler/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/rexml/parsers/baseparser.rb:184:in `pull'
    /Users/esigler/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/rexml/parsers/sax2parser.rb:92:in `parse'
    /Users/esigler/.rvm/gems/ruby-2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/streamparser.rb:91:in `parse'
    /Users/esigler/.rvm/gems/ruby-2.1.0/gems/xmpp4r-0.5.6/lib/xmpp4r/stream.rb:75:in `block in start'
```

The part of the string in question is:

```
address:        Humleg�rdsgatan 20
```

Forcing the string to be encoded as UTF-8, and replacing invalid or
undefined characters, prevents the Hipchat disconnect.
