### PR TITLE
Ignores socket errors that occur during shut_down

### DIFF
--- a/lib/lita/adapters/hipchat/connector.rb
+++ b/lib/lita/adapters/hipchat/connector.rb
@@ -99,6 +99,8 @@ module Lita
         def shut_down
           Lita.logger.info("Disconnecting from HipChat.")
           client.close
+        rescue IOError, SystemCallError => e
+          Lita.logger.warn("Encountered error during disconnect: #{e}")
         end
 
         private


### PR DESCRIPTION
If the socket has already disconnected, e.g., we don't want to raise _another_ error (see #34, #20) when trying to close it cleanly.

Scenario:
1. The socket disconnects for an unexpected reason.
2. An exception is raised when we try to write to it.
3. The [on\_exception handler is called](https://github.com/litaio/lita-hipchat/blob/9a11d47ee7a37376d19acb1a49564492acf1e7cf/lib/lita/adapters/hipchat/connector.rb#L119-L123), which starts shutting the robot down.
4. The [shut\_down](https://github.com/litaio/lita-hipchat/blob/9a11d47ee7a37376d19acb1a49564492acf1e7cf/lib/lita/adapters/hipchat/connector.rb#L99-L102) method is called.
5. By trying to close the socket cleanly, we attempt to write to it again, causing another exception (e.g., IOError or Errno::ECONNRESET)
6. The new exception bubbles up and lita doesn't exit cleanly.

I think we should log, but not re-raise, exceptions during shut down of the connector.

WDYT @MattMencel @sjernigan @jimmycuadra