### PR TITLE
Add email into user metadata.

### DIFF
--- a/lib/lita/adapters/hipchat/callback.rb
+++ b/lib/lita/adapters/hipchat/callback.rb
@@ -49,7 +49,8 @@ module Lita
           User.create(
             user_data["jid"],
             name: user_data["name"],
-            mention_name: user_data["mention_name"]
+            mention_name: user_data["mention_name"],
+            email: user_data["email"]
           )
         end
 


### PR DESCRIPTION
Our case is using email to validate if the user has privilege to send a command.
So email is very important and convenient if we could have it in user metadata.
