### PR TITLE
fix_broken_message_muc

### DIFF
--- a/lib/lita/adapters/hipchat.rb
+++ b/lib/lita/adapters/hipchat.rb
@@ -52,7 +52,7 @@ module Lita
         if target.private_message?
           connector.message_jid(target.user.id, strings)
         else
-          connector.message_muc(target.room, strings)
+          connector.message_muc(muc_domain, target.room, strings)
         end
       end
 

--- a/lib/lita/adapters/hipchat/connector.rb
+++ b/lib/lita/adapters/hipchat/connector.rb
@@ -70,7 +70,8 @@ module Lita
           end
         end
 
-        def message_muc(room_jid, strings)
+        def message_muc(muc_domain, room_jid, strings)
+          room_jid = [room_jid, muc_domain].join('@')
           muc = mucs[room_jid]
           strings.each do |s|
             Lita.logger.debug("Sending message to MUC #{room_jid}: #{s}")

--- a/spec/lita/adapters/hipchat/connector_spec.rb
+++ b/spec/lita/adapters/hipchat/connector_spec.rb
@@ -185,10 +185,10 @@ describe Lita::Adapters::HipChat::Connector, lita: true do
   describe "#message_muc" do
     it "sends the messages to the room" do
       muc = instance_double("Jabber::MUC::SimpleMUCClient")
-      allow(subject).to receive(:mucs).and_return("jid" => muc)
+      allow(subject).to receive(:mucs).and_return("jid@conf.hipchat.com" => muc)
       expect(muc).to receive(:say).with("foo")
       expect(muc).to receive(:say).with("bar")
-      subject.message_muc("jid", ["foo", "bar"])
+      subject.message_muc("conf.hipchat.com", "jid", ["foo", "bar"])
     end
   end
 

--- a/spec/lita/adapters/hipchat_spec.rb
+++ b/spec/lita/adapters/hipchat_spec.rb
@@ -154,7 +154,7 @@ describe Lita::Adapters::HipChat, lita: true do
   describe "#send_messages" do
     it "sends messages to rooms" do
       source = instance_double("Lita::Source", room: "room_id", private_message?: false)
-      expect(subject.connector).to receive(:message_muc).with("room_id", ["Hello!"])
+      expect(subject.connector).to receive(:message_muc).with("conf.hipchat.com", "room_id", ["Hello!"])
       subject.send_messages(source, ["Hello!"])
     end
 


### PR DESCRIPTION
The problem is: Lita can not send message to a room.
The reason is: Room ID in Lita does not include muc_domain.